### PR TITLE
Add optin/authentication callback processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Register a listener using `robot.on [EVENT_NAME] [CALLBACK]`.
 | `fb_delivery`                  | ```{ event: msgevent, user: hubot.user, room: string }```                               | Emitted when a delivery confirmation is sent.                                                                                                                              |
 | `fb_richMsg`                   | ```{ event: msgevent, user: hubot.user, room: string, attachments: array[msgevent.message.attachment]}```          | Emitted when a message with an attachment is sent. Contains all attachments within that message.                                                                           |
 | `fb_richMsg_[ATTACHMENT.TYPE]` | ```{ event: msgevent, user: hubot.user, room: string, attachment: msgevent.message.attachment}```          | Emitted when a message with an attachment is sent. Contains a single attachment of type [ATTACHMENT.TYPE], and multiple are emitted in messages with multiple attachments. |
+| `fb_optin` or `fb_authentication` | ``` { event: msgevent, user: hubot.user, room: string, ref: string } ``` | Emitted when an [authentication event](https://developers.facebook.com/docs/messenger-platform/plugin-reference#send_to_messenger) is triggered
 
 #### `fb_postback` example
 

--- a/src/fb.coffee
+++ b/src/fb.coffee
@@ -117,6 +117,8 @@ class FBMessenger extends Adapter
             @_processPostback event, envelope
         else if event.delivery?
             @_processDelivery event, envelope
+        else if event.optin?
+            @_processOptin event, envelope
             
     _processMessage: (event, envelope) ->
         @robot.logger.debug inspect event.message
@@ -155,6 +157,11 @@ class FBMessenger extends Adapter
         
     _processDelivery: (event, envelope) ->
         @robot.emit "fb_delivery", envelope
+    
+    _processOptin: (event, envelope) ->
+        envelope.ref = event.optin.ref
+        @robot.emit "fb_optin", envelope
+        @robot.emit "fb_authentication", envelope
         
     _getUser: (userId, page, callback) ->
         self = @


### PR DESCRIPTION
Reference: https://developers.facebook.com/docs/messenger-platform/webhook-reference#auth
also https://developers.facebook.com/docs/messenger-platform/plugin-reference#send_to_messenger

I have it emitting two events because Facebook seems conflicted about what to call this action. The object reference is for `optin` but docs reference `authentication`.
