### PR TITLE
fix oauth access token get from facebook

### DIFF
--- a/src/fb.coffee
+++ b/src/fb.coffee
@@ -238,7 +238,10 @@ class FBMessenger extends Adapter
 
         @robot.http(@appAccessTokenEndpoint)
             .get() (error, response, body) ->
-                self.app_access_token = body.split("=").pop()
+                body = JSON.parse body
+                unless body.access_token
+                  throw new Error('Cannot get oauth access token from Facebook')
+                self.app_access_token = body.access_token
                 self.robot.http(self.setWebhookEndpoint)
                 .query(
                     object: 'page',


### PR DESCRIPTION
Hello, last week our hubot stopped authenticating with FB. The root cause was a different response from FB when calling the access token endpoint.

I update the relevant code to cope with the new response, submitting as a PR hoping is useful and helpful to others using this adapter.
