### PR TITLE
Add quick replies postback

### DIFF
--- a/src/fb.coffee
+++ b/src/fb.coffee
@@ -124,7 +124,10 @@ class FBMessenger extends Adapter
         }
 
         if event.message?
-            @_processMessage event, envelope
+            if event.message.quick_reply?
+                @_processQuickReply event, envelope
+            else
+                @_processMessage event, envelope
         else if event.postback?
             @_processPostback event, envelope
         else if event.delivery?
@@ -162,6 +165,10 @@ class FBMessenger extends Adapter
             attachment: attachment
         }
         @robot.emit "fb_richMsg_#{attachment.type}", unique_envelope
+
+    _processQuickReply: (event, envelope) ->
+        envelope.payload = event.message.quick_reply.payload
+        @robot.emit "fb_postback", envelope
 
     _processPostback: (event, envelope) ->
         envelope.payload = event.postback.payload


### PR DESCRIPTION
The quick_reply's postback are inside message element.
The current version of adaptar process quick reply as plain message and without postback fired.